### PR TITLE
Fix docstring style for get_scores_by_mode()

### DIFF
--- a/score_service.py
+++ b/score_service.py
@@ -75,9 +75,7 @@ def get_user_scores(username):
 
 @app.get("/scores/<username>/<mode>")
 def get_scores_by_mode(username, mode):
-    """
-    Return all scores for a given user filtered by difficulty mode.
-    """
+    """Return all scores for a given user filtered by difficulty mode."""
     # Normalize mode (e.g. "easy", "E", "slow" → "Easy").
     normalized = normalize_mode(mode)
     


### PR DESCRIPTION
Fixes #4

Pull request standardizes the docstring for 'get_scores_by_mode()' to match the one-line format
used in other functions in the microservice.

- Converted multi-line single-sentence docstring into one-line format.
- No functional changes were made.

This resolves inconsistent conventions code smell identified in the code review.
